### PR TITLE
[v2] examples: Add a dummy clock example

### DIFF
--- a/software-rasp/gtk/glade-examples/clock.glade
+++ b/software-rasp/gtk/glade-examples/clock.glade
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.22.2 -->
+<interface>
+  <requires lib="gtk+" version="3.20"/>
+  <object class="GtkWindow" id="window">
+    <property name="can_focus">False</property>
+    <property name="title" translatable="yes">Dummy Clock</property>
+    <property name="default_width">200</property>
+    <property name="default_height">100</property>
+    <signal name="destroy" handler="onDestroy" swapped="no"/>
+    <child type="titlebar">
+      <placeholder/>
+    </child>
+    <child>
+      <object class="GtkBox">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="margin_left">10</property>
+        <property name="margin_right">10</property>
+        <property name="margin_top">10</property>
+        <property name="margin_bottom">10</property>
+        <property name="orientation">vertical</property>
+        <child>
+          <object class="GtkLabel" id="label">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="halign">center</property>
+            <property name="valign">center</property>
+            <property name="margin_top">10</property>
+            <property name="label" translatable="yes">0:00:00</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkToggleButton" id="stop">
+            <property name="label" translatable="yes">Stop</property>
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">True</property>
+            <signal name="toggled" handler="onButtonToggled" swapped="no"/>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="pack_type">end</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+  </object>
+</interface>

--- a/software-rasp/gtk/glade-examples/clock.py
+++ b/software-rasp/gtk/glade-examples/clock.py
@@ -1,0 +1,77 @@
+#!/usr/libexec/
+
+import gi
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk, GLib
+
+# Thread example
+from threading import Thread
+
+import time
+from datetime import datetime
+
+class Clock(Thread):
+    def __init__(self, label, button):
+        """ Clock constructor """
+        super(Clock, self).__init__()
+        self.label = label
+        self.button = button
+
+        # Dummy indicators
+        self.stopped = False
+        self.alive = True
+
+    def restart(self):
+        self.stopped = False
+
+    def stop(self):
+        self.stopped = True
+
+    def quit(self):
+        self.alive = False
+
+    def __update_clock(self):
+        """ Private Method: update widgets """
+        now = datetime.now() # current date and time
+        if not self.stopped:
+            self.label.set_text(now.strftime("%H:%M:%S"))
+            self.button.set_label("Stop")
+        else:
+            self.button.set_label("Continue")
+
+    def run(self):
+        while self.alive:
+            GLib.idle_add(self.__update_clock)
+            # 100ms to prove that update with
+            # Threads is able with GLib.
+            time.sleep(0.1)
+
+class Handler:
+    def __init__(self, label, button):
+        self.clock = Clock(label, button)
+        self.clock.start()
+
+    def onDestroy(self, *args):
+        self.clock.quit()
+        Gtk.main_quit()
+
+    def onButtonToggled(self, button):
+        if self.clock.stopped:
+            self.clock.restart()
+        else:
+            self.clock.stop()
+
+builder = Gtk.Builder()
+builder.add_from_file("clock.glade")
+
+window = builder.get_object("window")
+label = builder.get_object("label")
+button = builder.get_object("stop")
+
+handler = Handler(label, button)
+builder.connect_signals(handler)
+
+window.show_all()
+
+Gtk.main()


### PR DESCRIPTION
This commit adds a dummy clock event to show simple usage of Threads, GLib and Gtk widgets.

Signed-off-by: Julio Faracco <jcfaracco@gmail.com>